### PR TITLE
minSdkVersion changed from 28 to 21 and one redundant dependency removed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.dunai.home"
-        minSdkVersion 28
+        minSdkVersion 21
         targetSdkVersion 30
         versionCode 22
         versionName "1.22"
@@ -57,7 +57,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.1.1'
     implementation 'org.eclipse.paho:org.eclipse.paho.android.service:1.1.1'
-    implementation 'com.android.support:localbroadcastmanager:28.0.0'
+//    implementation 'com.android.support:localbroadcastmanager:28.0.0'
     implementation group: 'androidx.gridlayout', name: 'gridlayout', version: '1.0.0'
     implementation 'com.jjoe64:graphview:4.2.2'
     implementation 'com.github.woxthebox:draglistview:1.7.2'


### PR DESCRIPTION
The current `minSdkVersion` is unreasonably high 28 (Android 9). It may be safely lowered to 21 (Android 5.0) without any cost, which is actually done in this pull request. Additionally, the redundant dependency on `localbroadcastmanager` is removed.

