### PR TITLE
Cleanup of missed SDK 21+ usage

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,7 @@
       <item index="0" class="java.lang.String" itemvalue="androidx.lifecycle.OnLifecycleEvent" />
     </list>
   </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="org.jetbrains.annotations.Nullable" />
     <option name="myDefaultNotNull" value="androidx.annotation.NonNull" />
@@ -48,7 +49,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,4 +66,6 @@ dependencies {
     implementation "com.github.abhishekti7:UnicornFilePicker:1.0.1"
     implementation group: 'org.bouncycastle', name: 'bcprov-jdk15to18', version: '1.68'
     implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15to18', version: '1.68'
+
+    implementation 'com.annimon:stream:1.2.2'
 }

--- a/app/src/main/java/com/dunai/home/activities/AbstractWidgetEditActivity.java
+++ b/app/src/main/java/com/dunai/home/activities/AbstractWidgetEditActivity.java
@@ -9,15 +9,15 @@ import android.widget.SeekBar;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 
+import com.annimon.stream.Stream;
 import com.dunai.home.R;
 import com.dunai.home.client.HomeClient;
 import com.dunai.home.client.workspace.Widget;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Stream;
 
 public abstract class AbstractWidgetEditActivity extends AbstractEditActivity {
     private HomeClient client;
@@ -48,9 +48,11 @@ public abstract class AbstractWidgetEditActivity extends AbstractEditActivity {
         super.onCreate(savedInstanceState);
         setContentView(this.getLayoutResource());
 
-        Toolbar toolbar = findViewById(R.id.toolbar);
+        final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        final ActionBar actionBar = getSupportActionBar();
+        if(actionBar != null)
+            actionBar.setDisplayHomeAsUpEnabled(true);
 
         this.client = HomeClient.getInstance();
 
@@ -124,16 +126,17 @@ public abstract class AbstractWidgetEditActivity extends AbstractEditActivity {
     }
 
     protected boolean validateFields() {
-        AtomicBoolean errors = new AtomicBoolean(false);
-        Stream.concat(Stream.of(this.title), this.getRequiredFields().stream()).forEach(field -> {
-            if (field.getText().length() == 0) {
-                field.setError(getString(R.string.field_required));
-                errors.set(true);
-            } else {
-                field.setError(null);
-            }
-        });
-        return !errors.get();
+        final Boolean errors = Stream.concat(Stream.of(this.title), Stream.of(this.getRequiredFields()))
+                .reduce(Boolean.FALSE, (errorAccumulator, field) -> {
+                    if (field.getText().length() == 0) {
+                        field.setError(getString(R.string.field_required));
+                        return Boolean.TRUE;
+                    } else {
+                        field.setError(null);
+                        return errorAccumulator;
+                    }
+                });
+        return errors == null || !errors;
     }
 
     protected @Nullable

--- a/app/src/main/java/com/dunai/home/activities/reorder/RecyclerViewAdapter.java
+++ b/app/src/main/java/com/dunai/home/activities/reorder/RecyclerViewAdapter.java
@@ -14,7 +14,6 @@ import com.dunai.home.activities.interfaces.ItemTouchHelperAdapter;
 import com.dunai.home.client.workspace.Item;
 
 import java.util.ArrayList;
-import java.util.List;
 
 public class RecyclerViewAdapter extends RecyclerView.Adapter<ItemViewHolder> implements ItemTouchHelperAdapter {
     private final Context context;

--- a/app/src/main/java/com/dunai/home/client/HomeClient.java
+++ b/app/src/main/java/com/dunai/home/client/HomeClient.java
@@ -31,13 +31,10 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.lang.reflect.Array;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;

--- a/app/src/main/java/com/dunai/home/client/workspace/Section.java
+++ b/app/src/main/java/com/dunai/home/client/workspace/Section.java
@@ -4,7 +4,6 @@ import androidx.annotation.Nullable;
 
 import com.dunai.home.R;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 public class Section extends Item {

--- a/app/src/main/java/com/dunai/home/fragments/TilesFragment.java
+++ b/app/src/main/java/com/dunai/home/fragments/TilesFragment.java
@@ -41,7 +41,6 @@ import com.dunai.home.client.workspace.Section;
 import com.dunai.home.client.workspace.SliderWidget;
 import com.dunai.home.client.workspace.SwitchWidget;
 import com.dunai.home.client.workspace.TextWidget;
-import com.dunai.home.client.workspace.Widget;
 import com.dunai.home.renderers.AbstractRenderer;
 import com.dunai.home.renderers.ButtonWidgetRenderer;
 import com.dunai.home.renderers.ColorWidgetRenderer;
@@ -51,7 +50,6 @@ import com.dunai.home.renderers.SectionRenderer;
 import com.dunai.home.renderers.SliderWidgetRenderer;
 import com.dunai.home.renderers.SwitchWidgetRenderer;
 import com.dunai.home.renderers.TextWidgetRenderer;
-import com.dunai.home.renderers.WidgetRenderer;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/app/src/main/java/com/dunai/home/renderers/SectionRenderer.java
+++ b/app/src/main/java/com/dunai/home/renderers/SectionRenderer.java
@@ -5,10 +5,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.WindowManager;
 import android.widget.GridLayout;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.preference.PreferenceManager;

--- a/app/src/main/java/com/dunai/home/renderers/SliderWidgetRenderer.java
+++ b/app/src/main/java/com/dunai/home/renderers/SliderWidgetRenderer.java
@@ -71,7 +71,6 @@ public class SliderWidgetRenderer extends WidgetRenderer {
         super.notifyValueChanged();
     }
 
-
     private int mapWidgetToSeekBar(int value){
         return value - widgetMinValue;
     }

--- a/app/src/main/java/com/dunai/home/renderers/SliderWidgetRenderer.java
+++ b/app/src/main/java/com/dunai/home/renderers/SliderWidgetRenderer.java
@@ -14,16 +14,21 @@ import com.dunai.home.client.workspace.SliderWidget;
  */
 @SuppressLint("ViewConstructor")
 public class SliderWidgetRenderer extends WidgetRenderer {
+
     private final SeekBar seekBar;
+    private final int widgetMinValue;
 
     public SliderWidgetRenderer(Context context, SliderWidget workspaceSliderWidget, String value) {
         super(context, workspaceSliderWidget);
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         inflater.inflate(R.layout.slider_renderer, this.findViewById(R.id.rendererContainer), true);
 
+        widgetMinValue = workspaceSliderWidget.minValue;
+        final int sliderRange = workspaceSliderWidget.maxValue - workspaceSliderWidget.minValue;
+
         this.seekBar = this.findViewById(R.id.sliderRendererSeekBar);
-        this.seekBar.setMin(workspaceSliderWidget.minValue);
-        this.seekBar.setMax(workspaceSliderWidget.maxValue);
+        // SeekBar's minValue is 0 by default
+        this.seekBar.setMax(sliderRange);
 
         if (value != null) {
             this.setValue(value);
@@ -33,9 +38,10 @@ public class SliderWidgetRenderer extends WidgetRenderer {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
                 if (fromUser) {
+                    final int widgetValue = mapSeekBarToWidget(progress);
                     HomeClient.getInstance().publish(
                             workspaceSliderWidget.topic,
-                            String.valueOf(progress),
+                            String.valueOf(widgetValue),
                             workspaceSliderWidget.retain
                     );
                 }
@@ -57,10 +63,22 @@ public class SliderWidgetRenderer extends WidgetRenderer {
 
     public void setValue(String value) {
         try {
-            this.seekBar.setProgress(Integer.parseInt(value));
+            int widgetValue = Integer.parseInt(value);
+            this.seekBar.setProgress(mapWidgetToSeekBar(widgetValue));
         } catch (Exception e) {
             //
         }
         super.notifyValueChanged();
     }
+
+
+    private int mapWidgetToSeekBar(int value){
+        return value - widgetMinValue;
+    }
+
+    private int mapSeekBarToWidget(int value){
+        return widgetMinValue + value;
+    }
+
+
 }


### PR DESCRIPTION
The missed calls of SDK21+ API which leads to the runtime app crashes got removed/replaced:
1. `SeekBar.setMin(int)` is available only on SDK 26+ (method call removed and a simple value mapping implemented)
2. Default implementation of Java `Stream` API is is available only on SDK 24+ (implementation replaced with the opensource backport)